### PR TITLE
PR #1: CSV naming convention changes + fixing audio file checks

### DIFF
--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -356,10 +356,12 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]
         output_format = "translation"
 
-    the_date_time = str(datetime.now().strftime("%H:%M"))
+    now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
+    #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
+    print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -4,7 +4,7 @@ import csv
 import time
 from datetime import datetime
 import magic
-from typing import Any, List, Optional
+from typing import List
 from pyannote.audio import Pipeline
 from backend.merge_timestamps import diarize_text
 from iso639 import Lang

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -216,7 +216,8 @@ def writing_solo_res_to_csv(comb_result) -> List:
             # step 5: write entire row into csv
             csv_content.append(row_to_write)
 
-            # step 6: change value of curr_speaker to speaker (officially "switching" the counter variable curr_speaker to reflect actual value from variable speaker)
+            # step 6: change value of curr_speaker to speaker
+            # (officially "switching" the counter variable curr_speaker to reflect actual value from variable speaker)
             curr_speaker = speaker
 
             # step 7: modify the value of the beginning timestamp to reflect when the new speaker starts talking

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -1,6 +1,5 @@
 ## Import statements ##
 import whisper
-# import pandas as pd # Commented out import since the method importing it is not in current use
 import csv
 import time
 from datetime import datetime

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -21,7 +21,6 @@ def validate_audio_file(audio_file_path: str) -> bool:
         other "types" of files has not been implemented yet
     """
     validate_audio_path_msg = magic.from_file(audio_file_path, mime=True)
-    print(validate_audio_path_msg)
     supported_file_extensions = {"mpeg", "mp4", "wav", "webm", "flac", "ogg", "adts"}
     #Note: In above line, mpeg include checks for mpeg, mp3 and mpga. mp4 includes checks for .mp4 and .m4a
     # adts files can include some audio files disguised as mp3/mp4

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -22,7 +22,8 @@ def validate_audio_file(audio_file_path: str) -> bool:
         other "types" of files has not been implemented yet
     """
     validate_audio_path_msg = magic.from_file(audio_file_path, mime=True)
-    supported_file_extensions = {"mpeg", "mp4", "wav"} #mpeg include checks for mp3, mp4 includes checks for .mp4 and .m4a
+    supported_file_extensions = {"mpeg", "mp4", "wav", "webm"}
+    #Note: In above line, mpeg include checks for mpeg, mp3 and mpga. mp4 includes checks for .mp4 and .m4a
     for file_ext in supported_file_extensions:
         if file_ext in validate_audio_path_msg:
             return True


### PR DESCRIPTION
### PR fix for issues: #7, #13

Here are a list of changes to the PR:

**1. Changing CSV file name to follow the naming convention:**

file_name_transcription_time.csv

OR 

file_name_translation_time.csv

depending on selected choice. 

**_NOTE: There is a bug with the naming, see comments below._** 

**_NOTE 2: Will re-add renaming for the dual transcription + translation features once PR #11 has been reviewed or feedback provided._** 

**2. Expanding audio file metadata checks**

All file extensions as listed in issue #7 should be implemented in method `validate_audio_file`.