### PR TITLE
Implementing dual transcription + translation features 

### DIFF
--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -363,7 +363,6 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: There is a bug where inserting a ":" in between the hours and minutes causes an extra '\' to appear
-    print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -314,7 +314,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         output_format = "translation"
     else: # reaching here means: process_selected == 'Transcription + Translation Only'
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
-        output_format = "transcribe_translate"
+        output_format = "transcribe&translate"
 
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -314,12 +314,12 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         output_format = "translation"
     else: # reaching here means: process_selected == 'Transcription + Translation Only'
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
-        output_format = "transcribe&translate"
+        output_format = "transcribe_translate"
 
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: There is a bug where inserting a ":" in between the hours and minutes causes an extra '\' to appear
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv"
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -21,11 +21,12 @@ def validate_audio_file(audio_file_path: str) -> bool:
         - Audio file inputs are either .wav or .mp3. Whisper can process more audio file inputs, but the checking for
         other "types" of files has not been implemented yet
     """
-    validate_audio_path_msg = magic.from_file(audio_file_path)
-    if "WAVE audio" in validate_audio_path_msg or "Audio file" in validate_audio_path_msg: # TODO: 1st cond => .wav file. 2nd cond => .mp3 files
-        return True
-    else:
-        return False
+    validate_audio_path_msg = magic.from_file(audio_file_path, mime=True)
+    supported_file_extensions = {"mpeg", "mp4", "wav"} #mpeg include checks for mp3, mp4 includes checks for .mp4 and .m4a
+    for file_ext in supported_file_extensions:
+        if file_ext in validate_audio_path_msg:
+            return True
+    return False
 
 def define_whisper_model(model_path: str):
     """
@@ -372,9 +373,6 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         print("")
         print(f'Detected language in input audio file: {whisper_detect_lang}')
         print("")
-        # Step 5: Conducting speaker diarization on the file (this step is the same for both transcription and translation)
-        # TODO: Using a possible check (using an intermediate variable denoting whether or not diarization is complete...
-        # TODO (CONT): ... + using the https://pypi.org/project/progress/ library, can add a spinner to denote diarization running
         print("Speaker diarization has started, in progress")
         print("")
         diarize_model = diarize_model

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -260,7 +260,6 @@ def writing_comb_res_to_csv(comb_list_1, comb_list_2) -> List:
     else:
         length_limit = result_1_len
         res_with_min_length = 1
-    print("Length limit: ", length_limit)
 
     # Step 2: Create a list of list object starting from length 0 up to the length_limit
     comb_csv_content = []

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -156,8 +156,10 @@ def display_timestamps_speaker_and_text(whisper_result, speaker_diaz_result):
 #             autodetect_csv_content[i].append(eng_csv_content[i][-1])
 #             comb_lang_csv_writer.writerow(autodetect_csv_content[i])
 
-def gen_group_speakers_csv_content(comb_result) -> List:
+def translate_or_transcribe_only_csv(comb_result) -> List:
     """
+    NOTE: This function is ONLY used to write content to TRANSCRIPTION / TRANSLATION ONLY
+    files.
     This method returns a List that contain the parsed information
     from object comb_result. This information is intended to be written into a CSV file
     where the speakers are GROUPED TOGETHER / CLUBBED TOGETHER.
@@ -391,7 +393,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
             transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                              diarization_result)
-            transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
+            transcript_csv_content = translate_or_transcribe_only_csv(transcript_final_result)
             print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
             write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
@@ -400,7 +402,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("Translating audio file to English\n")
             trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
+            trans_csv_content = translate_or_transcribe_only_csv(trans_lang_final_result)
             print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
             write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
@@ -411,13 +413,13 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
             transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                           diarization_result)
-            transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
+            transcript_csv_content = translate_or_transcribe_only_csv(transcript_final_result)
             print("Done transcription\n")
 
             print("Now, translating audio file to English\n")
             trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
+            trans_csv_content = translate_or_transcribe_only_csv(trans_lang_final_result)
             print("Done translation\n")
 
             print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -352,14 +352,19 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     if process_selected == "Transcription Only":
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"] # Insert your headers here by replacing values of empty strings. Eg: ["Timestamps", "Speaker No", "Text[Eng]"]
         output_format = "transcription"
-    else:
+    elif process_selected == "Translation Only":
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]
         output_format = "translation"
+    else: # reaching here means: process_selected == 'Transcription + Translation Only'
+        output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
+        output_format = "translate_+_transcribe"
 
-    the_date_time = str(datetime.now().strftime("%H:%M"))
+    now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
+    #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
+    print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -373,11 +373,9 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
         # Step 4: Processing and printing out detected language
         whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
-        print("")
         print(f'Detected language in input audio file: {whisper_detect_lang}\n')
-        #print("")
+
         print("Speaker diarization has started, in progress\n")
-        #print("")
         diarize_model = diarize_model
         the_audio = whisper.load_audio(input_audio_path, 16000)
         audio_data = {
@@ -386,34 +384,26 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         }
         diarization_result = diarize_model(audio_data)
         print("Speaker diarization has completed\n")
-        #print("")
 
         # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
-        # TODO: Look into whether the print("") could be replaced with a built-in newline character in the prior print statement (to reduce print calls)
         if (process_selected == "Transcription Only"):
             print("Transcribing audio file\n")
-            #print("")
             transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
             transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                              diarization_result)
             transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
             print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
-            #print("")
             write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
-            #print("")
 
         elif (process_selected == "Translation Only") or (translate_to_english == "Yes"):
             print("Translating audio file to English\n")
-            #print("")
             trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
             trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
             print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
-            #print("")
             write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
-            #print("")
 
         else: #If reached here, then process_selected == "translate_+_transcribe"
             print("Transcribing audio file\n")
@@ -429,6 +419,8 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
             trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
             print("Done translation\n")
+
+            print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
 
 
     else:

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -362,8 +362,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
-    #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: There is a bug where inserting a ":" in between the hours and minutes causes an extra '\' to appear
     print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
@@ -391,38 +390,27 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         print("")
 
         # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
-
-        if whisper_detect_lang == "English": # Case 1: The audio file is in English. Only available option is to transcribe to english
+        # TODO: Look into whether the print("") could be replaced with a built-in newline character in the prior print statement (to reduce print calls)
+        if process_selected == "Transcription Only":
             print("Transcribing audio file")
             print("")
-            autodetect_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
-            pure_eng_lang_final_result = display_timestamps_speaker_and_text(autodetect_whisper_result, diarization_result)
-            pure_eng_csv_content = gen_group_speakers_csv_content(pure_eng_lang_final_result)
+            transcription_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcription_final_result = display_timestamps_speaker_and_text(transcription_whisper_result,
+                                                                             diarization_result)
+            pure_eng_csv_content = gen_group_speakers_csv_content(transcription_final_result)
             print("Finished transcribing audio file. Writing output as a CSV file to destination...")
             print("")
             write_list_to_csv(pure_eng_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete")
             print("")
 
-        elif translate_to_english: # Case 2: The audio file is in another language. Here, we want to translate text to english.
+        elif process_selected == "Translation Only":
             print("Translating audio file to English")
             print("")
             eng_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             eng_lang_final_result = display_timestamps_speaker_and_text(eng_whisper_result, diarization_result)
             eng_csv_content = gen_group_speakers_csv_content(eng_lang_final_result)
             print("Finished translating audio file to English. Writing output as a CSV file to destination...")
-            print("")
-            write_list_to_csv(eng_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete")
-            print("")
-
-        else: # Case 2: The audio file is in another language. Here, we want to transcribe text based on the autodetected language
-            print("Transcribing audio file")
-            print("")
-            eng_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
-            eng_lang_final_result = display_timestamps_speaker_and_text(eng_whisper_result, diarization_result)
-            eng_csv_content = gen_group_speakers_csv_content(eng_lang_final_result)
-            print("Finished transcribing audio file. Writing output as a CSV file to destination...")
             print("")
             write_list_to_csv(eng_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -374,10 +374,10 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         # Step 4: Processing and printing out detected language
         whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
         print("")
-        print(f'Detected language in input audio file: {whisper_detect_lang}')
-        print("")
-        print("Speaker diarization has started, in progress")
-        print("")
+        print(f'Detected language in input audio file: {whisper_detect_lang}\n')
+        #print("")
+        print("Speaker diarization has started, in progress\n")
+        #print("")
         diarize_model = diarize_model
         the_audio = whisper.load_audio(input_audio_path, 16000)
         audio_data = {
@@ -385,34 +385,34 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             'sample_rate': 16000
         }
         diarization_result = diarize_model(audio_data)
-        print("Speaker diarization has completed")
-        print("")
+        print("Speaker diarization has completed\n")
+        #print("")
 
         # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
         # TODO: Look into whether the print("") could be replaced with a built-in newline character in the prior print statement (to reduce print calls)
         if process_selected == "Transcription Only":
-            print("Transcribing audio file")
-            print("")
+            print("Transcribing audio file\n")
+            #print("")
             transcription_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
             transcription_final_result = display_timestamps_speaker_and_text(transcription_whisper_result,
                                                                              diarization_result)
             pure_eng_csv_content = gen_group_speakers_csv_content(transcription_final_result)
-            print("Finished transcribing audio file. Writing output as a CSV file to destination...")
-            print("")
+            print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
+            #print("")
             write_list_to_csv(pure_eng_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete")
-            print("")
+            print("CSV file has been created. Process is complete\n")
+            #print("")
 
         elif process_selected == "Translation Only":
-            print("Translating audio file to English")
-            print("")
+            print("Translating audio file to English\n")
+            #print("")
             eng_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             eng_lang_final_result = display_timestamps_speaker_and_text(eng_whisper_result, diarization_result)
             eng_csv_content = gen_group_speakers_csv_content(eng_lang_final_result)
-            print("Finished translating audio file to English. Writing output as a CSV file to destination...")
-            print("")
+            print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
+            #print("")
             write_list_to_csv(eng_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete")
-            print("")
+            print("CSV file has been created. Process is complete\n")
+            #print("")
     else:
         print("Invalid file format. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -28,7 +28,7 @@ def validate_audio_file(audio_file_path: str) -> bool:
             return True
     return False
 
-def define_whisper_model(model_path: str):
+def define_whisper_model(model_path: str, is_english: bool):
     """
     This method downloads a Whisper model by loading in a .pt file in the directory
     specified by parameter model_path
@@ -49,7 +49,15 @@ def define_whisper_model(model_path: str):
     """
     # TODO: Need to handle cases where invalid model path is passed, need to add conditional checks for that
     # TODO #2: Need to determine what is the return type of the model?
-    whisper_model = whisper.load_model(model_path)
+    if (is_english == "Yes" and model_path == "small"):
+        whisper_model = whisper.load_model("small.en")
+        print("chosen small.en")
+    elif (is_english == "Yes" and model_path == "medium"):
+        whisper_model = whisper.load_model("medium.en")
+        print("chosen medium.en")
+    else:
+        whisper_model = whisper.load_model(model_path)
+        print("chosen: " + model_path)
     return whisper_model
 
 def detecting_language(whisper_model: Any, audio_file_path: str) -> str:
@@ -331,11 +339,14 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     is_valid_audio_file = validate_audio_file(input_audio_path)
     if (is_valid_audio_file):
         # Step 3: Defining whisper model
-        loaded_whisper_model = define_whisper_model(model_size_selection)
+        loaded_whisper_model = define_whisper_model(model_size_selection, translate_to_english)
 
         # Step 4: Processing and printing out detected language
-        whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
-        print(f'Detected language in input audio file: {whisper_detect_lang}\n')
+        if (translate_to_english == "Yes"):
+            print("Detected language in input audio file: English\n")
+        else:
+            whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
+            print(f'Detected language in input audio file: {whisper_detect_lang}\n')
 
         print("Speaker diarization has started, in progress\n")
         diarize_model = diarize_model
@@ -368,21 +379,22 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("CSV file has been created. Process is complete\n")
 
         else: #If reached here, then process_selected == "translate_+_transcribe"
-            print("Transcribing audio file\n")
-
-            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
-            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
-                                                                          diarization_result)
-            transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
-            print("Done transcription\n")
-
-            print("Now, translating audio file to English\n")
-            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
-            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
-            print("Done translation\n")
-
-            print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
+            # TODO: Nothing in this part is finalized yet, temporairly commented out
+            # print("Transcribing audio file\n")
+            #
+            # transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            # transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
+            #                                                               diarization_result)
+            # transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
+            # print("Done transcription\n")
+            #
+            # print("Now, translating audio file to English\n")
+            # trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+            # trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+            # trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
+            # print("Done translation\n")
+            #
+            # print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
 
 
     else:

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -357,7 +357,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         output_format = "translation"
     else: # reaching here means: process_selected == 'Transcription + Translation Only'
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
-        output_format = "translate_+_transcribe"
+        output_format = "transcribe&translate"
 
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
@@ -390,29 +390,46 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
         # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
         # TODO: Look into whether the print("") could be replaced with a built-in newline character in the prior print statement (to reduce print calls)
-        if process_selected == "Transcription Only":
+        if (process_selected == "Transcription Only"):
             print("Transcribing audio file\n")
             #print("")
-            transcription_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
-            transcription_final_result = display_timestamps_speaker_and_text(transcription_whisper_result,
+            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                              diarization_result)
-            pure_eng_csv_content = gen_group_speakers_csv_content(transcription_final_result)
+            transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
             print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
             #print("")
-            write_list_to_csv(pure_eng_csv_content, output_csv_path, output_csv_headers)
+            write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
             #print("")
 
-        elif process_selected == "Translation Only":
+        elif (process_selected == "Translation Only") or (translate_to_english == "Yes"):
             print("Translating audio file to English\n")
             #print("")
-            eng_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
-            eng_lang_final_result = display_timestamps_speaker_and_text(eng_whisper_result, diarization_result)
-            eng_csv_content = gen_group_speakers_csv_content(eng_lang_final_result)
+            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+            trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
             print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
             #print("")
-            write_list_to_csv(eng_csv_content, output_csv_path, output_csv_headers)
+            write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
             #print("")
+
+        else: #If reached here, then process_selected == "translate_+_transcribe"
+            print("Transcribing audio file\n")
+
+            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
+                                                                          diarization_result)
+            transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
+            print("Done transcription\n")
+
+            print("Now, translating audio file to English\n")
+            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+            trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
+            print("Done translation\n")
+
+
     else:
         print("Invalid file format. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -3,7 +3,7 @@ import whisper
 # import pandas as pd # Commented out import since the method importing it is not in current use
 import csv
 import time
-import datetime
+from datetime import datetime
 import magic
 from typing import Any, List, Optional
 from pyannote.audio import Pipeline
@@ -348,17 +348,20 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     # Step 1: Defining input audio path + defining CSV Headers
     input_audio_path = input_file # Insert audio file name and extension here (extensions can include: .mp3, .wav)
     output_csv_headers = [] # Insert your headers here by replacing values of empty strings. Eg: ["Timestamps", "Speaker No", "Text[Eng]"]
+    output_format = ""
     if process_selected == "Transcription Only":
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"]
+        output_format = "transcription"
     else:
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]
-    #elif process_selected == "Translation Only":
-    #    output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]
-    #else:
-    #    output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
-    the_date_time = str(datetime.datetime.now()).replace("-", "_").replace(" ", "_").replace(":", "_").replace(".", "_")
-    output_csv_path = destination_selection + "/" + the_date_time + "_" + "streetwhisperapp.csv"
-    translate_to_english = to_english_selection # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
+        output_format = "translation"
+
+    #the_date_time = str(datetime.datetime.now()).replace("-", "_").replace(" ", "_").replace(":", "_").replace(".", "_")
+    the_date_time = str(datetime.now().strftime("%H:%M"))
+    audio_path_last_backslash_index = input_file.rfind("/")
+    audio_name = input_file[audio_path_last_backslash_index + 1:]
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
+    translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format
     is_valid_audio_file = validate_audio_file(input_audio_path)

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -347,16 +347,14 @@ def write_list_to_csv(list_of_csv_content: List[str], output_csv_path: str, outp
 def main(process_selected: str, input_file: str, to_english_selection: bool, model_size_selection: str, destination_selection: str, diarize_model):
     # Step 1: Defining input audio path + defining CSV Headers
     input_audio_path = input_file # Insert audio file name and extension here (extensions can include: .mp3, .wav)
-    output_csv_headers = [] # Insert your headers here by replacing values of empty strings. Eg: ["Timestamps", "Speaker No", "Text[Eng]"]
-    output_format = ""
+
     if process_selected == "Transcription Only":
-        output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"]
+        output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"] # Insert your headers here by replacing values of empty strings. Eg: ["Timestamps", "Speaker No", "Text[Eng]"]
         output_format = "transcription"
     else:
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]
         output_format = "translation"
 
-    #the_date_time = str(datetime.datetime.now()).replace("-", "_").replace(" ", "_").replace(":", "_").replace(".", "_")
     the_date_time = str(datetime.now().strftime("%H:%M"))
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
@@ -368,7 +366,6 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     if (is_valid_audio_file):
         # Step 3: Defining whisper model
         loaded_whisper_model = define_whisper_model(model_size_selection)
-        # loaded_whisper_model = define_whisper_model(f'whisper_models/{model_size_selection}.pt')  # Insert .pt model to replace the "xxxx.pt" placeholder text
 
         # Step 4: Processing and printing out detected language
         whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -261,43 +261,6 @@ def translate_or_transcribe_only_csv(comb_result) -> List:
                 csv_content.append(row_to_write)
     return csv_content
 
-def write_audio_text_obj_to_csv(csv_headers: List[str], csv_file_path: str, comb_result):
-    """
-    Default settings for writing an audio text obj (the return object from method display_timestamps_speaker_and_text)
-    to CSV without grouping/clubbing by speakers
-
-    A CSV with the following format would be returned:
-
-    Column 1: Timestamps (in HH:MM:SS) format (hour, minute, second)
-    Column 2: Speaker No (String denoting the identification of speakers)
-    Column 3: Column is named Text[Orig Lang] if the comb_result contains text
-    based on Whisper's autodetected language. Otherwise, it is named Text[Eng]
-
-    Preconditions:
-        - csv_headers contains only the column names listed above
-    """
-    with open(csv_file_path, "w") as csv_file:
-        csv_writer = csv.writer(csv_file)
-        csv_writer.writerow(csv_headers)  # Write the header row
-        for i in range(len(comb_result)):
-            row_to_write = []
-            seg = comb_result[i][0]
-            start_timestamp_as_time_obj = time.gmtime(float(seg.start))
-            converted_start_timestamp = time.strftime("%H:%M:%S",start_timestamp_as_time_obj)
-
-            end_timestamp_as_time_obj = time.gmtime(float(seg.end))
-            converted_end_timestamp = time.strftime("%H:%M:%S", end_timestamp_as_time_obj)
-
-            full_timestamp = converted_start_timestamp + "-" + converted_end_timestamp
-            row_to_write.append(full_timestamp)
-
-            speaker = comb_result[i][1]
-            row_to_write.append(speaker)
-
-            speaker_text = comb_result[i][2]
-            row_to_write.append(speaker_text)
-
-            csv_writer.writerow(row_to_write)
 
 def write_list_to_csv(list_of_csv_content: List[str], output_csv_path: str, output_csv_headers: List[str]) -> None:
     """

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -1,6 +1,5 @@
 ## Import statements ##
 import whisper
-# import pandas as pd # Commented out import since the method importing it is not in current use
 import csv
 import time
 from datetime import datetime

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -314,7 +314,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         output_format = "translation"
     else: # reaching here means: process_selected == 'Transcription + Translation Only'
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]", "Text[Eng]"]
-        output_format = "transcribe&translate"
+        output_format = "transcribe_translate"
 
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -358,7 +358,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
 
-        elif (process_selected == "Translation Only"):
+        elif (process_selected == "Translation Only" or translate_to_english == "Yes"):
             print("Translating audio file to English\n")
             trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
             trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -368,24 +368,25 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("CSV file has been created. Process is complete\n")
 
         else: #If reached here, then process_selected == "translate_+_transcribe"
-            print("TODO")
-            # TODO: Nothing in this part is finalized yet, temporairly commented out
-            # print("Transcribing audio file\n")
-            #
-            # transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
-            # transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
-            #                                                               diarization_result)
-            # transcript_csv_content = gen_group_speakers_csv_content(transcript_final_result)
-            # print("Done transcription\n")
-            #
-            # print("Now, translating audio file to English\n")
-            # trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
-            # trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            # trans_csv_content = gen_group_speakers_csv_content(trans_lang_final_result)
-            # print("Done translation\n")
-            #
-            # print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
+            print("Transcribing audio file\n")
+            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
+                                                                          diarization_result)
+            transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
+            print("Done transcription\n")
 
+            print("Now, translating audio file to English\n")
+            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+            trans_csv_content = writing_solo_res_to_csv(trans_lang_final_result)
+            print("Done translation\n")
+
+            print("Combining transcription and translation results")
+            combo_csv_content = writing_comb_res_to_csv(transcript_csv_content,trans_csv_content)
+
+            print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
+            write_list_to_csv(combo_csv_content, output_csv_path, output_csv_headers)
+            print("CSV file has been created. Process is complete\n")
 
     else:
         print("Invalid file format. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -156,7 +156,7 @@ def display_timestamps_speaker_and_text(whisper_result, speaker_diaz_result):
 #             autodetect_csv_content[i].append(eng_csv_content[i][-1])
 #             comb_lang_csv_writer.writerow(autodetect_csv_content[i])
 
-def translate_or_transcribe_only_csv(comb_result) -> List:
+def translate_or_transcribe_only_csv(comb_result_1, comb_result_2) -> List:
     """
     NOTE: This function is ONLY used to write content to TRANSCRIPTION / TRANSLATION ONLY
     files.
@@ -183,29 +183,29 @@ def translate_or_transcribe_only_csv(comb_result) -> List:
     00:00:40 - 00:00:50 | Speaker 1 | "A cat?"
     00:00:50 - 00:00:55 | Speaker 0 | "Yes."
     """
-    curr_speaker = comb_result[0][1]  # Denotes the speaker that is currently "speaking" in the iteration
-    initial_seg = comb_result[0][0]
+    curr_speaker = comb_result_1[0][1]  # Denotes the speaker that is currently "speaking" in the iteration
+    initial_seg = comb_result_1[0][0]
     start_timestamp_as_time_obj = time.gmtime(float(initial_seg.start))
     beg_speaker_timestamp = time.strftime("%H:%M:%S", start_timestamp_as_time_obj)
 
     end_timestamp_as_time_obj = time.gmtime(float(initial_seg.end))
     end_speaker_timestamp = time.strftime("%H:%M:%S", end_timestamp_as_time_obj)
 
-    speaker_text_seg = comb_result[0][2]
+    speaker_text_seg = comb_result_1[0][2]
 
     csv_content = []
 
-    for i in range(1, len(comb_result)):
-        seg = comb_result[i][0]
-        speaker = comb_result[i][1]  # Denotes the speaker that is currently "speaking" in the iteration
+    for i in range(1, len(comb_result_1)): #TODO might need to modify this check based on whether comb_result_2 exists
+        seg = comb_result_1[i][0]
+        speaker = comb_result_1[i][1]  # Denotes the speaker that is currently "speaking" in the iteration
 
-        if (speaker == curr_speaker) and i < len(comb_result) - 1:
-            speaker_text_seg = speaker_text_seg + comb_result[i][2]
+        if (speaker == curr_speaker) and i < len(comb_result_1) - 1:
+            speaker_text_seg = speaker_text_seg + comb_result_1[i][2]
             end_timestamp_as_time_obj = time.gmtime(float(seg.end))
             end_speaker_timestamp = time.strftime("%H:%M:%S", end_timestamp_as_time_obj)
 
-        elif (speaker == curr_speaker) and i == len(comb_result) - 1:
-            speaker_text_seg = speaker_text_seg + comb_result[i][2]
+        elif (speaker == curr_speaker) and i == len(comb_result_1) - 1:
+            speaker_text_seg = speaker_text_seg + comb_result_1[i][2]
             end_timestamp_as_time_obj = time.gmtime(float(seg.end))
             end_speaker_timestamp = time.strftime("%H:%M:%S", end_timestamp_as_time_obj)
             # In addition to the above, since we reached the end of the iteration, need to write to csv file
@@ -250,9 +250,9 @@ def translate_or_transcribe_only_csv(comb_result) -> List:
             end_speaker_timestamp = time.strftime("%H:%M:%S", end_timestamp_as_time_obj)
 
             # step 9: change value of speaker_text_seg to be the text seg corresponding to the speaker at this current time
-            speaker_text_seg = comb_result[i][2]
+            speaker_text_seg = comb_result_1[i][2]
 
-            if i == len(comb_result) - 1:
+            if i == len(comb_result_1) - 1:
                 row_to_write = []
                 full_timestamp = beg_speaker_timestamp + "-" + end_speaker_timestamp
                 row_to_write.append(full_timestamp)
@@ -260,7 +260,6 @@ def translate_or_transcribe_only_csv(comb_result) -> List:
                 row_to_write.append(speaker_text_seg)
                 csv_content.append(row_to_write)
     return csv_content
-
 
 def write_list_to_csv(list_of_csv_content: List[str], output_csv_path: str, output_csv_headers: List[str]) -> None:
     """

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -60,6 +60,9 @@ def questions_ui(diarize_model):
                 },
                 {
                     'name': 'Translation Only',
+                },
+                {
+                    'name': 'Transcription + Translation Only',
                 }
             ],
         }


### PR DESCRIPTION
### PR fix for issues: #9, #16

**Status: Completed rough implementation of #9, #16**

_More details regarding #9:_ Implemented a new method called `writing_comb_res_to_csv` that takes the lists from transcription and translation results. It creates a new list that combines the transcription and translation results. 

Note: If the amount of content from transcription and translation is NOT THE SAME, then for some fields, you would see the string "N/A" displayed. 

_More details regarding #16_ : Only the small and medium have pure .en models. Therefore, checks are only added for these 2 cases. There is only 1 large-v2 model.
