### PR TITLE
Updated Invalid Audio Path Message and Updates Spaces in Audio File

### DIFF
--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -363,24 +363,21 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
     # Remove leading and trailing whitespace from audio_name
     audio_name = audio_name.strip()
-    print("Audio name after stripping: ", audio_name)
     # Replace any "  " which both represent a space in audio file with _
     audio_name = "_".join(audio_name.split())
-    print("Audio name after replacing spaces: ", audio_name)
     # Remove leading and trailing whitespace from destination_selection
     destination_selection = destination_selection.strip()
 
     # Constructing output csv path string
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + str(now.minute) + ".csv"
-    print("Output csv path: ", output_csv_path)
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + "_" + str(now.minute) + ".csv"
+    print("For reference, this is the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
     # Step 2: Check if audio file is in valid format
     # Remove leading and trailing whitespace from input audio path
-    input_audio_path = (input_audio_path.strip())[0:audio_path_last_backslash_index + 1] + audio_name
-    print("Input audio path: ", input_audio_path)
+    input_audio_path = input_audio_path.strip()
+    input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
     is_valid_audio_file = validate_audio_file(input_audio_path)
-    print("Made it past input audio path check")
 
     if (is_valid_audio_file):
         # Step 3: Defining whisper model

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -359,12 +359,18 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
+    # Remove leading and trailing whitespace
+    audio_name = audio_name.strip()
+    # Replace any "  " which both represent a space in audio file with _
+    audio_name = audio_name.replace(" ", "_")
     #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
     print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format
+    # Remove leading and trailing whitespace from input audio path
+    input_audio_path = input_audio_path.strip()
     is_valid_audio_file = validate_audio_file(input_audio_path)
     if (is_valid_audio_file):
         # Step 3: Defining whisper model
@@ -425,4 +431,4 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("CSV file has been created. Process is complete")
             print("")
     else:
-        print("Invalid file format. Please try again")
+        print("Invalid file format or input file could not be found. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -346,6 +346,7 @@ def write_list_to_csv(list_of_csv_content: List[str], output_csv_path: str, outp
 #     data3.to_csv(comb_lang_csv_file, encoding='utf-8', index=False)
 
 def main(process_selected: str, input_file: str, to_english_selection: bool, model_size_selection: str, destination_selection: str, diarize_model):
+
     # Step 1: Defining input audio path + defining CSV Headers
     input_audio_path = input_file # Insert audio file name and extension here (extensions can include: .mp3, .wav)
 
@@ -359,19 +360,23 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     now = datetime.now()
     audio_path_last_backslash_index = input_file.rfind("/")
     audio_name = input_file[audio_path_last_backslash_index + 1:]
-    # Remove leading and trailing whitespace
+
+    # Remove leading and trailing whitespace from audio_name
     audio_name = audio_name.strip()
     # Replace any "  " which both represent a space in audio file with _
     audio_name = audio_name.replace(" ", "_")
-    #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
-    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
-    print(output_csv_path)
-    translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
+    # Remove leading and trailing whitespace from destination_selection
+    destination_selection = destination_selection.strip()
+
+    # Constructing output csv path string
+    output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + str(now.minute) + ".csv"
+    translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
     # Step 2: Check if audio file is in valid format
     # Remove leading and trailing whitespace from input audio path
     input_audio_path = input_audio_path.strip()
     is_valid_audio_file = validate_audio_file(input_audio_path)
+
     if (is_valid_audio_file):
         # Step 3: Defining whisper model
         loaded_whisper_model = define_whisper_model(model_size_selection)

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -337,6 +337,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
     # Constructing output csv path string
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + "_" + str(now.minute) + ".csv"
+    print("This will be the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
     # Step 2: Check if audio file is in valid format

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -363,19 +363,24 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
     # Remove leading and trailing whitespace from audio_name
     audio_name = audio_name.strip()
+    print("Audio name after stripping: ", audio_name)
     # Replace any "  " which both represent a space in audio file with _
-    audio_name = audio_name.replace(" ", "_")
+    audio_name = "_".join(audio_name.split())
+    print("Audio name after replacing spaces: ", audio_name)
     # Remove leading and trailing whitespace from destination_selection
     destination_selection = destination_selection.strip()
 
     # Constructing output csv path string
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + str(now.minute) + ".csv"
+    print("Output csv path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
     # Step 2: Check if audio file is in valid format
     # Remove leading and trailing whitespace from input audio path
-    input_audio_path = input_audio_path.strip()
+    input_audio_path = (input_audio_path.strip())[0:audio_path_last_backslash_index + 1] + audio_name
+    print("Input audio path: ", input_audio_path)
     is_valid_audio_file = validate_audio_file(input_audio_path)
+    print("Made it past input audio path check")
 
     if (is_valid_audio_file):
         # Step 3: Defining whisper model

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -370,7 +370,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
     # Constructing output csv path string
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + "_" + str(now.minute) + ".csv"
-    print("For reference, this is the output path: ", output_csv_path)
+    print("This will be the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
     # Step 2: Check if audio file is in valid format


### PR DESCRIPTION
In this PR, the following changes were made:
- Trailing and leading whitespace is removed from `audio_name` and `input_audio_path`. 
- Updated invalid audio path message to `Invalid file format or input file could not be found. Please try again` in order to also indicate that the input audio file path may not exist.
- Replaced all spaces in `audio_name` to `_` so that the output CSV file does not contain any spaces.