### PR TITLE
Exiting Program Gracefully and Included Check if User Doesn't Use Keyboard and Enter Key To Make Selection

### DIFF
--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -92,7 +92,7 @@ def questions_ui(diarize_model):
                 },
                 {
                     'name': 'Exit the app',
-                },
+                }
             ],
         }
     ]

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -22,6 +22,8 @@ def authorization():
         diarize_model = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=str(potential_access_token))
         questions_ui(diarize_model)
         typer.Exit()
+    except KeyboardInterrupt:
+        typer.Exit()
     except:
         invalidTokenPrompt = [
             {

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -22,6 +22,30 @@ def authorization():
         diarize_model = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=str(potential_access_token))
         questions_ui(diarize_model)
         typer.Exit()
+    except KeyError: 
+        # You reach here if you click on a selection in the prompt selection instead of 
+        # using your keyboard
+        invalidKeyError  = [
+            {
+                'type': 'list',
+                'name': 'key_error',
+                'message': 'Please only use your keyboard and the enter key when making a selection.',
+                'choices': [
+                    {
+                        'name': 'I would like to try again',
+                    },
+                    {
+                        'name': 'Exit the app',
+                    }
+                ],
+            }
+        ]
+        key_error = prompt(invalidKeyError)
+        if key_error != {} and key_error["key_error"] == 'I would like to try again':
+            authorization()
+        else:
+            typer.Exit()
+        
     except KeyboardInterrupt:
         typer.Exit()
     except:
@@ -62,11 +86,16 @@ def questions_ui(diarize_model):
                 },
                 {
                     'name': 'Translation Only',
-                }
+                },
+                {
+                    'name': 'Exit the app',
+                },
             ],
         }
     ]
     process_selected = prompt(translation_transcription_prompt)
+    if process_selected["process_selected"] == 'Exit the app':
+        return 
     # Input file
     rprint("[blue]=============================[blue]")
     rprint(f"[bold]Enter the absolute path to the audio file you want to do the \"{process_selected['process_selected']}\" process on:[bold]")
@@ -86,10 +115,15 @@ def questions_ui(diarize_model):
                 {
                     'name': 'No',
                 },
+                {
+                    'name': 'Exit the app',
+                },         
             ],
         }
     ]
     to_english_selection = prompt(to_eng_selection_prompt)
+    if to_english_selection["to_english_selection"] == 'Exit the app':
+        return
 
     rprint("[blue]=============================[blue]")
     # Model size selection
@@ -108,10 +142,15 @@ def questions_ui(diarize_model):
                 {
                     'name': 'medium',
                 },
+                {
+                    'name': 'Exit the app',
+                },
             ],
         }
     ]
     model_size_selection = prompt(model_size_selection_prompt)
+    if model_size_selection["model_size_selection"] == 'Exit the app':
+        return
     rprint("[blue]=============================[blue]")
     # Destination Folder
     rprint(f"[bold]Enter the absolute path to your destination folder:[bold]")


### PR DESCRIPTION
In this PR: 
- Script now checks for keyboard interruption and exits the app. It no longer throws error messages or shows the invalid token error.
- In order to fix the problem where you have to use CTRL-C a couple of times while you are currently on a list-type prompt, every list-type prompt has an option to exit the app. 
- Included check for KeyError, which happens if the user doesn't use their keyboard and enter key to make a selection. This check gives the user the option to go through the steps again. If they continue to not use their keyboard and enter key, app will be exited.