### PR TITLE
Making code compatable with Pyinstaller + Minor typo correction

### DIFF
--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -4,7 +4,7 @@ import csv
 import time
 from datetime import datetime
 import magic
-from typing import Any, Optional, List
+#from typing import Any, Optional, List
 from pyannote.audio import Pipeline
 from backend.merge_timestamps import diarize_text
 from iso639 import Lang
@@ -79,7 +79,7 @@ def detecting_language(whisper_model, audio_file_path: str) -> str:
     full_language = Lang(detected_lang_code).name # decoding the language code
     return full_language
 
-def transcribe_audio(whisper_model: Any, audio_file_path: str, is_translate: Optional[bool] = False):
+def transcribe_audio(whisper_model, audio_file_path: str, is_translate: bool):
     """
     This method takes an audio file with the path as specified by parameter audio_file_path.
     It also takes a boolean is_translate. If true, we wish to translate the transcribed text to English.
@@ -96,7 +96,7 @@ def transcribe_audio(whisper_model: Any, audio_file_path: str, is_translate: Opt
     Preconditions:
         - Audio file path is defined and links to a .wav file.
     """
-    if is_translate:
+    if is_translate == True:
         transcription = whisper_model.transcribe(audio=audio_file_path, task="translate", fp16=False, verbose=False)
     else:
         transcription = whisper_model.transcribe(audio=audio_file_path, fp16=False, verbose=False)
@@ -134,7 +134,7 @@ def display_timestamps_speaker_and_text(whisper_result, speaker_diaz_result):
     """
     return diarize_text(whisper_result, speaker_diaz_result)
 
-def writing_solo_res_to_csv(comb_result) -> List:
+def writing_solo_res_to_csv(comb_result):
     """
     NOTE: This method is a helper method for CSV writing in the case when
     user selects "Transcription only" or "Translation only".
@@ -240,7 +240,7 @@ def writing_solo_res_to_csv(comb_result) -> List:
                 row_to_write.append(speaker_text_seg)
                 csv_content.append(row_to_write)
     return csv_content
-def writing_comb_res_to_csv(comb_list_1, comb_list_2) -> List:
+def writing_comb_res_to_csv(comb_list_1, comb_list_2):
     """
     NOTE: This method is a helper method for CSV writing in the case when
     user selects "Transcription + Translation".
@@ -294,7 +294,7 @@ def writing_comb_res_to_csv(comb_list_1, comb_list_2) -> List:
 
     return comb_csv_content
 
-def write_list_to_csv(list_of_csv_content: List[List[str]], output_csv_path: str, output_csv_headers: List[str]) -> None:
+def write_list_to_csv(list_of_csv_content, output_csv_path: str, output_csv_headers) -> None:
     """
     This method writes a list of strings (which is the expected output from the method
     writing_solo_res_to_csv or writing_comb_res_to_csv.
@@ -355,7 +355,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
         if (process_selected == "Transcription Only"):
             print("Transcribing audio file\n")
-            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
             transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                              diarization_result)
             transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
@@ -374,7 +374,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
 
         else: #If reached here, then process_selected == "translate_+_transcribe"
             print("Transcribing audio file\n")
-            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path)
+            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
             transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
                                                                           diarization_result)
             transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -300,17 +300,18 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     audio_name = input_file[audio_path_last_backslash_index + 1:]
     #output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + the_date_time + "_" + ".csv"
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + str(now.hour) + "_" + str(now.minute) + ".csv" #TODO: Bug with: "THIS TOKEN IS INVALID"
-    # print(output_csv_path)
     translate_to_english = to_english_selection    # True denotes that if audio file is not in english, you want to translate text to english. If False, text would be transcribed based on autodetected language from Whisper
 
     # Step 2: Check if audio file is in valid format
     is_valid_audio_file = validate_audio_file(input_audio_path)
     if (is_valid_audio_file):
+        print("Made it past audio file check")
         # Step 3: Defining whisper model
         loaded_whisper_model = define_whisper_model(model_size_selection)
-
+        print("Made it past loading whisper model")
         # Step 4: Processing and printing out detected language
         whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
+        print("Made it past detecting language")
         print("")
         print(f'Detected language in input audio file: {whisper_detect_lang}')
         print("")
@@ -337,6 +338,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
             write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
+            return
 
         elif (process_selected == "Translation Only" or translate_to_english == "Yes"):
             print("Translating audio file to English\n")
@@ -346,6 +348,8 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
             print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
             write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
             print("CSV file has been created. Process is complete\n")
+            return
         # TODO: Temporarily removed the conditional for the dual transcription + translation process
     else:
         print("Invalid file format. Please try again")
+        return

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pyannote.audio==3.1.1
 iso639-lang
 python-magic-bin==0.4.14
 
-typing
 datetime
 torch
 ffmpeg

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -15,15 +15,23 @@ def startup_ui():
     authorization()
 
 def authorization():
-    rprint(f"What is your access token? An access token from Hugging Face and accepting pyannote/speaker-diarization-3.1's user condition is needed to run the app. If this is not your first time running the app amd have previously entered a valid token, you can just press enter on your keyboard.[bold]")
-    potential_access_token = input()
+    access_token_prompt = [
+        {
+            'type': 'password',
+            'message': 'What is your access token? An access token from Hugging Face and accepting pyannote/speaker-diarization-3.1\'s user condition is needed to run the app. If this is not your first time running the app and have previously entered a valid token, you can just press enter on your keyboard.\n',
+            'name': 'password'
+        }
+    ]
+    potential_access_token = prompt(access_token_prompt)
+    if (potential_access_token["password"].lower() == "exit"):
+        return
     try:
         # Check token
         diarize_model = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=str(potential_access_token))
         questions_ui(diarize_model)
         typer.Exit()
-    except KeyError: 
-        # You reach here if you click on a selection in the prompt selection instead of 
+    except KeyError:
+        # You reach here if you click on a selection in the prompt selection instead of
         # using your keyboard
         invalidKeyError  = [
             {
@@ -45,7 +53,7 @@ def authorization():
             authorization()
         else:
             typer.Exit()
-        
+
     except KeyboardInterrupt:
         typer.Exit()
     except:
@@ -98,7 +106,7 @@ def questions_ui(diarize_model):
     ]
     process_selected = prompt(translation_transcription_prompt)
     if process_selected["process_selected"] == 'Exit the app':
-        return 
+        return
     # Input file
     rprint("[blue]=============================[blue]")
     rprint(f"[bold]Enter the absolute path to the audio file you want to do the \"{process_selected['process_selected']}\" process on:[bold]")
@@ -120,7 +128,7 @@ def questions_ui(diarize_model):
                 },
                 {
                     'name': 'Exit the app',
-                },         
+                },
             ],
         }
     ]

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -18,7 +18,7 @@ def authorization():
     access_token_prompt = [
         {
             'type': 'password',
-            'message': 'What is your access token? An access token from Hugging Face and accepting pyannote/speaker-diarization-3.1\'s user condition is needed to run the app. If this is not your first time running the app and have previously entered a valid token, you can just press enter on your keyboard.\n',
+            'message': 'What is your access token? An access token from Hugging Face and accepting pyannote/speaker-diarization-3.1\'s user condition is needed to run the app. If this is not your first time running the app and you have previously entered a valid token, press enter on your keyboard.\n',
             'name': 'password'
         }
     ]

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -23,7 +23,7 @@ def authorization():
         }
     ]
     potential_access_token = prompt(access_token_prompt)
-    if (potential_access_token["password"].lower() == "exit"):
+    if (potential_access_token == {} or potential_access_token["password"].lower() == "exit"):
         return
     try:
         # Check token

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -18,7 +18,7 @@ def authorization():
     access_token_prompt = [
         {
             'type': 'password',
-            'message': 'What is your access token? An access token from Hugging Face and accepting pyannote/speaker-diarization-3.1\'s user condition is needed to run the app. If this is not your first time running the app and you have previously entered a valid token, press enter on your keyboard.\n',
+            'message': 'What is your access token? An access token from Hugging Face and accepting \npyannote/speaker-diarization-3.1\'s user condition is needed to run the app.\nIf this is not your first time running the app and you have previously entered a valid token,\npress enter on your keyboard.\n',
             'name': 'password'
         }
     ]

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -18,7 +18,7 @@ def authorization():
     access_token_prompt = [
         {
             'type': 'password',
-            'message': 'What is your access token? An access token from Hugging Face and accepting \npyannote/speaker-diarization-3.1\'s user condition is needed to run the app.\nIf this is not your first time running the app and you have previously entered a valid token,\npress enter on your keyboard.\n',
+            'message': 'What is your access token? An access token from Hugging Face and accepting \npyannote/speaker-diarization-3.1\'s user condition is needed to run the app.\nIf this is not your first time running the app and you have previously entered a\nvalid token, press enter on your keyboard.\n',
             'name': 'password'
         }
     ]


### PR DESCRIPTION
### Addressing Issue #22 +  the typo bug in issue #17 + addressing issue #23

**Changes for issue #22**: Removed the `typing` package import to remove Pyinstaller bug. 

**Changes for issue #17**: Correct the word `amd` to `and` in the token prompt. 

**Changes for issue #23**: Implemented the `password` input type for the token prompt. All token prompts would be hidden using * characters. 

Furthermore, implemented a feature where if the user types in "exit" instead of a valid password (or an invalid password), the CLI would automatically exit. 