### PR TITLE
Fixing token authentication for first-time users

### DIFF
--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -27,7 +27,7 @@ def authorization():
         return
     try:
         # Check token
-        diarize_model = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=str(potential_access_token))
+        diarize_model = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=str(potential_access_token["password"]))
         questions_ui(diarize_model)
         typer.Exit()
     except KeyError:


### PR DESCRIPTION
Fixed the download of the `pyannote/speaker-diarization-3.1` gated model for first time users