### PR TITLE
Added options (-howtouse and -credits), updated way to start app, and found fix to random options error (ex: -B) 

### DIFF
--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -7,7 +7,7 @@ from pyannote.audio import Pipeline
 
 app = typer.Typer()
 
-def startup_ui(howtouse: bool = typer.Option(False, '-howtouse', help="Explains how to use tool"),
+def startup_ui(howtouse: bool = typer.Option(False, '-howtouse', help="How to use the tool"),
                credits: bool = typer.Option(False, '-credits', help="Credits")):
     if not howtouse and not credits: 
         # When no option is passed in, the app will start

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -7,12 +7,20 @@ from pyannote.audio import Pipeline
 
 app = typer.Typer()
 
-@app.command("start")
-def startup_ui():
-    rprint("[magenta]=============================[magenta]")
-    rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
-    rprint("[magenta]=============================[magenta]")
-    authorization()
+def startup_ui(howtouse: bool = typer.Option(False, '-howtouse', help="Explains how to use tool"),
+               credits: bool = typer.Option(False, '-credits', help="Credits")):
+    if not howtouse and not credits: 
+        # When no option is passed in, the app will start
+        rprint("[magenta]=============================[magenta]")
+        rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
+        rprint("[magenta]=============================[magenta]")
+        authorization()
+    if howtouse and not credits:
+        # When -howtouse is used, it will display the help section
+        howtouse_ui()
+    if not howtouse and credits:
+        # When -credits is used, it will display the credits section
+        credits_ui()
 
 def authorization():
     access_token_prompt = [
@@ -191,14 +199,26 @@ def questions_ui(diarize_model):
         # Exit out of app
         typer.Exit()
 
-@app.command("help")
-def help_ui():
+# How to use (previously: help) section 
+# (note: this is different from the option --help, which list out all the options the user can use)
+# Called by using the option -howtouse
+def howtouse_ui():
     rprint("[magenta]=============================[magenta]")
     rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
     rprint("")
-    rprint("[bold]Help[bold]")
+    rprint("[bold]How to Use[bold]")
+    rprint("[magenta]=============================[magenta]")
+    
+# Credits section
+# Called by using the option -credits
+def credits_ui():
+    rprint("[magenta]=============================[magenta]")
+    rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
+    rprint("")
+    rprint("[bold]Credits[bold]")
+    rprint("This application was created by STREET Lab (https://www.streetlab.tech/).")
+    rprint("For details about the technologies and libraries used, visit the following repository: https://github.com/moonsdust/street-whisper-app.")
     rprint("[magenta]=============================[magenta]")
 
-
 if __name__ == "__main__":
-    app()
+    typer.run(startup_ui)

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -9,7 +9,7 @@ app = typer.Typer()
 
 def startup_ui(howtouse: bool = typer.Option(False, '-howtouse', help="How to use the tool"),
                credits: bool = typer.Option(False, '-credits', help="Credits")):
-    if not howtouse and not credits: 
+    if not howtouse and not credits:
         # When no option is passed in, the app will start
         rprint("[magenta]=============================[magenta]")
         rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
@@ -199,7 +199,8 @@ def questions_ui(diarize_model):
         # Exit out of app
         typer.Exit()
 
-# How to use (previously: help) section 
+#TODO: Need to complete this method later
+# How to use (previously: help) section
 # (note: this is different from the option --help, which list out all the options the user can use)
 # Called by using the option -howtouse
 def howtouse_ui():
@@ -208,7 +209,7 @@ def howtouse_ui():
     rprint("")
     rprint("[bold]How to Use[bold]")
     rprint("[magenta]=============================[magenta]")
-    
+
 # Credits section
 # Called by using the option -credits
 def credits_ui():
@@ -216,8 +217,8 @@ def credits_ui():
     rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
     rprint("")
     rprint("[bold]Credits[bold]")
-    rprint("This application was created by STREET Lab (https://www.streetlab.tech/).")
-    rprint("For details about the technologies and libraries used, visit the following repository: https://github.com/moonsdust/street-whisper-app.")
+    rprint("This application was created by STREET Lab: https://www.streetlab.tech/ ")
+    rprint("For details about the technologies and libraries used, visit the following repository: https://github.com/moonsdust/street-whisper-app")
     rprint("[magenta]=============================[magenta]")
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR, the CLI was updated so that it supports the following options: 
- `-howtouse`: Explains how to use tool  (To use this, run the following command: `./streetwhisperapp -howtouse` (if with generated exe) or `python streetwhisperapp -howtouse` (if directly interacting with the script))
- `-credits`: Credits section (To use this, run the following command: `./streetwhisperapp -credits` (if with generated exe) or `python streetwhisperapp -credits` (if directly interacting with the script))
- `--help`: Shows all the options available (To use this, run the following command: `./streetwhisperapp --help` (if with generated exe) or `python streetwhisperapp --help` (if directly interacting with the script))

This will be added soon into #21 but in order to start the app, you no longer need to use the start command and instead just use the command `./streetwhisperapp` (if running the generated exe) or `python streetwhisperapp` (if running the script).

If you are generating an executable file, to stop error messages from showing up during the translation/transcription process like "No such option: -B", etc., see #29.


