### PR TITLE
Adding invalid path checking (for both the audio file + destination folder) 

### DIFF
--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -339,73 +339,73 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     print("This will be the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
-    # Step 2: Check if audio file is in valid format
-    # Remove leading and trailing whitespace from input audio path
-    input_audio_path = input_audio_path.strip()
-    input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
-    is_valid_audio_file = validate_audio_file(input_audio_path)
+    # # Step 2: Check if audio file is in valid format
+    # # Remove leading and trailing whitespace from input audio path
+    # input_audio_path = input_audio_path.strip()
+    # input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
+    # is_valid_audio_file = validate_audio_file(input_audio_path)
 
-    if (is_valid_audio_file):
-        # Step 3: Defining whisper model
-        loaded_whisper_model = define_whisper_model(model_size_selection, translate_to_english)
+    # if (is_valid_audio_file):
+    # Step 3: Defining whisper model
+    loaded_whisper_model = define_whisper_model(model_size_selection, translate_to_english)
 
-        # Step 4: Processing and printing out detected language
-        if (translate_to_english == "Yes"):
-            print("Detected language in input audio file: English\n")
-        else:
-            whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
-            print(f'Detected language in input audio file: {whisper_detect_lang}\n')
-
-        print("Speaker diarization has started, in progress\n")
-        diarize_model = diarize_model
-        the_audio = whisper.load_audio(input_audio_path, 16000)
-        audio_data = {
-            'waveform': torch.from_numpy(the_audio[None, :]),
-            'sample_rate': 16000
-        }
-        diarization_result = diarize_model(audio_data)
-        print("Speaker diarization has completed\n")
-
-        # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
-        if (process_selected == "Transcription Only"):
-            print("Transcribing audio file\n")
-            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
-            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
-                                                                             diarization_result)
-            transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
-            print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
-            write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete\n")
-
-        elif (process_selected == "Translation Only" or translate_to_english == "Yes"):
-            print("Translating audio file to English\n")
-            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
-            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            trans_csv_content = writing_solo_res_to_csv(trans_lang_final_result)
-            print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
-            write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete\n")
-
-        else: #If reached here, then process_selected == "translate_+_transcribe"
-            print("Transcribing audio file\n")
-            transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
-            transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
-                                                                          diarization_result)
-            transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
-            print("Done transcription\n")
-
-            print("Now, translating audio file to English\n")
-            trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
-            trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
-            trans_csv_content = writing_solo_res_to_csv(trans_lang_final_result)
-            print("Done translation\n")
-
-            print("Combining transcription and translation results")
-            combo_csv_content = writing_comb_res_to_csv(transcript_csv_content,trans_csv_content)
-
-            print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
-            write_list_to_csv(combo_csv_content, output_csv_path, output_csv_headers)
-            print("CSV file has been created. Process is complete\n")
-
+    # Step 4: Processing and printing out detected language
+    if (translate_to_english == "Yes"):
+        print("Detected language in input audio file: English\n")
     else:
-        print("Invalid file format or input file could not be found. Please try again")
+        whisper_detect_lang = detecting_language(loaded_whisper_model, input_audio_path)
+        print(f'Detected language in input audio file: {whisper_detect_lang}\n')
+
+    print("Speaker diarization has started, in progress\n")
+    diarize_model = diarize_model
+    the_audio = whisper.load_audio(input_audio_path, 16000)
+    audio_data = {
+        'waveform': torch.from_numpy(the_audio[None, :]),
+        'sample_rate': 16000
+    }
+    diarization_result = diarize_model(audio_data)
+    print("Speaker diarization has completed\n")
+
+    # Step 6: Running conditional checks. The code to run will differ based on whether detected language is ENG or not.
+    if (process_selected == "Transcription Only"):
+        print("Transcribing audio file\n")
+        transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
+        transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
+                                                                             diarization_result)
+        transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
+        print("Finished transcribing audio file. Writing output as a CSV file to destination...\n")
+        write_list_to_csv(transcript_csv_content, output_csv_path, output_csv_headers)
+        print("CSV file has been created. Process is complete\n")
+
+    elif (process_selected == "Translation Only" or translate_to_english == "Yes"):
+        print("Translating audio file to English\n")
+        trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+        trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+        trans_csv_content = writing_solo_res_to_csv(trans_lang_final_result)
+        print("Finished translating audio file to English. Writing output as a CSV file to destination...\n")
+        write_list_to_csv(trans_csv_content, output_csv_path, output_csv_headers)
+        print("CSV file has been created. Process is complete\n")
+
+    else: #If reached here, then process_selected == "translate_+_transcribe"
+        print("Transcribing audio file\n")
+        transcript_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=False)
+        transcript_final_result = display_timestamps_speaker_and_text(transcript_whisper_result,
+                                                                          diarization_result)
+        transcript_csv_content = writing_solo_res_to_csv(transcript_final_result)
+        print("Done transcription\n")
+
+        print("Now, translating audio file to English\n")
+        trans_whisper_result = transcribe_audio(loaded_whisper_model, input_audio_path, is_translate=True)
+        trans_lang_final_result = display_timestamps_speaker_and_text(trans_whisper_result, diarization_result)
+        trans_csv_content = writing_solo_res_to_csv(trans_lang_final_result)
+        print("Done translation\n")
+
+        print("Combining transcription and translation results")
+        combo_csv_content = writing_comb_res_to_csv(transcript_csv_content,trans_csv_content)
+
+        print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
+        write_list_to_csv(combo_csv_content, output_csv_path, output_csv_headers)
+        print("CSV file has been created. Process is complete\n")
+
+    # else:
+    #     print("Invalid file format or input file could not be found. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -4,7 +4,6 @@ import csv
 import time
 from datetime import datetime
 import magic
-#from typing import Any, Optional, List
 from pyannote.audio import Pipeline
 from backend.merge_timestamps import diarize_text
 from iso639 import Lang

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -335,6 +335,7 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     destination_selection = destination_selection.strip()
 
     # Constructing output csv path string
+    # TODO: There is a bug with this (has to do when there is a space in the audio name)
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + "_" + str(now.minute) + ".csv"
     print("This will be the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -3,29 +3,10 @@ import whisper
 import csv
 import time
 from datetime import datetime
-import magic
 from pyannote.audio import Pipeline
 from backend.merge_timestamps import diarize_text
 from iso639 import Lang
 import torch
-
-def validate_audio_file(audio_file_path: str) -> bool:
-    """
-    This function utilizes calls from the python-magic-bin==0.4.14 library to check whether or not the file denoted
-    by the path: audio_file_path is a valid audio file that can be interpreted by Whisper.
-
-    Preconditions:
-        - Audio file inputs are either .wav or .mp3. Whisper can process more audio file inputs, but the checking for
-        other "types" of files has not been implemented yet
-    """
-    validate_audio_path_msg = magic.from_file(audio_file_path, mime=True)
-    supported_file_extensions = {"mpeg", "mp4", "wav", "webm", "flac", "ogg", "adts"}
-    #Note: In above line, mpeg include checks for mpeg, mp3 and mpga. mp4 includes checks for .mp4 and .m4a
-    # adts files can include some audio files disguised as mp3/mp4
-    for file_ext in supported_file_extensions:
-        if file_ext in validate_audio_path_msg:
-            return True
-    return False
 
 def define_whisper_model(model_path: str, is_english: bool):
     """

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -335,18 +335,10 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
     destination_selection = destination_selection.strip()
 
     # Constructing output csv path string
-    # TODO: There is a bug with this (has to do when there is a space in the audio name)
     output_csv_path = destination_selection + "/" + audio_name + "_" + output_format + "_" + str(now.hour) + "_" + str(now.minute) + ".csv"
     print("This will be the output path: ", output_csv_path)
     translate_to_english = to_english_selection # True denotes that file is in ENG. Only transcription is needed
 
-    # # Step 2: Check if audio file is in valid format
-    # # Remove leading and trailing whitespace from input audio path
-    # input_audio_path = input_audio_path.strip()
-    # input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
-    # is_valid_audio_file = validate_audio_file(input_audio_path)
-
-    # if (is_valid_audio_file):
     # Step 3: Defining whisper model
     loaded_whisper_model = define_whisper_model(model_size_selection, translate_to_english)
 
@@ -407,6 +399,3 @@ def main(process_selected: str, input_file: str, to_english_selection: bool, mod
         print("Finished both transcription and translation. Writing output as a CSV file to destination...\n")
         write_list_to_csv(combo_csv_content, output_csv_path, output_csv_headers)
         print("CSV file has been created. Process is complete\n")
-
-    # else:
-    #     print("Invalid file format or input file could not be found. Please try again")

--- a/backend/whisper_with_diarization_as_methods.py
+++ b/backend/whisper_with_diarization_as_methods.py
@@ -311,10 +311,10 @@ def write_list_to_csv(list_of_csv_content, output_csv_path: str, output_csv_head
 def main(process_selected: str, input_file: str, to_english_selection: bool, model_size_selection: str, destination_selection: str, diarize_model):
 
     # Step 1: Defining input audio path + defining CSV Headers
-    input_audio_path = input_file # Insert audio file name and extension here (extensions can include: .mp3, .wav)
+    input_audio_path = input_file
 
     if process_selected == "Transcription Only":
-        output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"] # Insert your headers here by replacing values of empty strings. Eg: ["Timestamps", "Speaker No", "Text[Eng]"]
+        output_csv_headers = ["Timestamps", "Speaker No", "Text[Orig Lang]"]
         output_format = "transcription"
     elif process_selected == "Translation Only":
         output_csv_headers = ["Timestamps", "Speaker No", "Text[Eng]"]

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -31,8 +31,6 @@ def validate_path(input_path: str, is_intended_file: bool) -> bool:
 
     If is_intended_audio_file is true, then the expected path should point to a file.
     We can adjust the testing of the file_path based on this parameter
-
-    TBD: It also checks whether the user has the valid permissions corresponding to the path
     """
     if (is_intended_file):
         # In this branch, check whether path points to a valid file

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -11,6 +11,7 @@ app = typer.Typer()
 
 def startup_ui(howtouse: bool = typer.Option(False, '-howtouse', help="How to use the tool"),
                credits: bool = typer.Option(False, '-credits', help="Credits")):
+    """This function creates a UI based on the command given by the user."""
     if not howtouse and not credits:
         # When no option is passed in, the app will start
         rprint("[magenta]=============================[magenta]")
@@ -65,7 +66,9 @@ def validate_audio_file(audio_file_path: str) -> bool:
         if file_ext in validate_audio_path_msg:
             return True
     return False
+
 def authorization():
+    """This function deals with access token authentication, catching errors, keyboard interruptions, and more."""
     access_token_prompt = [
         {
             'type': 'password',
@@ -274,11 +277,12 @@ def questions_ui(diarize_model):
         # Exit out of app
         typer.Exit()
 
-#TODO: Need to complete this method later
+#TODO: Need to complete this function later
 # How to use (previously: help) section
 # (note: this is different from the option --help, which list out all the options the user can use)
 # Called by using the option -howtouse
 def howtouse_ui():
+    """This function creates the how to use section."""
     rprint("[magenta]=============================[magenta]")
     rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
     rprint("")
@@ -288,6 +292,7 @@ def howtouse_ui():
 # Credits section
 # Called by using the option -credits
 def credits_ui():
+    """This function creates the credits section."""
     rprint("[magenta]=============================[magenta]")
     rprint("[bold][underline]STREET Lab Whisper App[underline][bold]")
     rprint("")

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -174,8 +174,8 @@ def questions_ui(diarize_model):
         audio_name = input_file[audio_path_last_backslash_index + 1:]
         audio_name = audio_name.strip()  # remove leading and trailing whitespace
         # TODO: Purposefully left out the "replace <spaces> with <"_"> since that might interfere with the path checking
+        # TODO: Moreover, having spaces in path name still yields an actual valid path (at least for MacOS)
         input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
-        print("Revised input audio path: ", input_audio_path)
         is_valid_audio_path = validate_path(input_audio_path, True)
         if is_valid_audio_path:
             break

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -163,6 +163,9 @@ def questions_ui(diarize_model):
     # Input file
     rprint("[blue]=============================[blue]")
     rprint(f"[bold]Enter the absolute path to the audio file you want to do the \"{process_selected['process_selected']}\" process on:[bold]")
+
+    # Check if audio file path is a valid path within system that CLI is running from
+
     while True:
         input_file = input()
         input_audio_path = input_file.strip()  # remove leading and trailing whitespace
@@ -179,6 +182,7 @@ def questions_ui(diarize_model):
         else:
             print("You entered an invalid audio path. Please try again")
 
+    # Check if the referenced audio file itself is one that Whisper can process
 
     rprint("[blue]=============================[blue]")
     # Is Input File in English?
@@ -233,9 +237,11 @@ def questions_ui(diarize_model):
     rprint("[blue]=============================[blue]")
     # Destination Folder
     rprint(f"[bold]Enter the absolute path to your destination folder:[bold]")
+
+    # Check if dest file path is a valid path within system that CLI is running from
     while True:
         destination_selection = input()
-        destination_selection = destination_selection.strip() # remove leading and trailing whitespace
+        destination_selection = destination_selection.strip()  # remove leading and trailing whitespace
         is_valid_dest_path = validate_path(destination_selection, False)
         if is_valid_dest_path:
             break

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -183,6 +183,10 @@ def questions_ui(diarize_model):
             print("You entered an invalid audio path. Please try again")
 
     # Check if the referenced audio file itself is one that Whisper can process
+    is_valid_audio_file = validate_audio_file(input_audio_path)
+    if not (is_valid_audio_file):
+        print("The file type is not supported by Whisper. If you think this is not the case, please contact the developers")
+        return
 
     rprint("[blue]=============================[blue]")
     # Is Input File in English?

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -133,6 +133,9 @@ def authorization():
             typer.Exit()
 
 def questions_ui(diarize_model):
+    """This function asks prompts about the audio file that the user wants to translate
+    or perform transcription on and conducts file checks. Afterwards, information
+    is passed to backend."""
     rprint("[magenta]=============================[magenta]")
     rprint(f"You can now go offline.[bold]")
     rprint("[magenta]=============================[magenta]")

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -1,6 +1,6 @@
 from backend import whisper_with_diarization_as_methods
 import os
-import sys
+import magic
 import typer
 from PyInquirer import prompt
 from rich import print as rprint
@@ -49,6 +49,24 @@ def validate_path(input_path: str, is_intended_file: bool) -> bool:
             return True
         else:
             return False
+
+def validate_audio_file(audio_file_path: str) -> bool:
+    """
+    This function utilizes calls from the python-magic-bin==0.4.14 library to check whether or not the file denoted
+    by the path: audio_file_path is a valid audio file that can be interpreted by Whisper.
+
+    Preconditions:
+        - Audio file inputs are either .wav or .mp3. Whisper can process more audio file inputs, but the checking for
+        other "types" of files has not been implemented yet
+    """
+    validate_audio_path_msg = magic.from_file(audio_file_path, mime=True)
+    supported_file_extensions = {"mpeg", "mp4", "wav", "webm", "flac", "ogg", "adts"}
+    #Note: In above line, mpeg include checks for mpeg, mp3 and mpga. mp4 includes checks for .mp4 and .m4a
+    # adts files can include some audio files disguised as mp3/mp4
+    for file_ext in supported_file_extensions:
+        if file_ext in validate_audio_path_msg:
+            return True
+    return False
 def authorization():
     access_token_prompt = [
         {

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -184,7 +184,7 @@ def questions_ui(diarize_model):
         if is_valid_audio_path:
             break
         else:
-            print("You entered an invalid audio path. Please try again")
+            print("You entered an invalid audio path. Please try again:")
 
     # Check if the referenced audio file itself is one that Whisper can process
     is_valid_audio_file = validate_audio_file(input_audio_path)
@@ -254,7 +254,7 @@ def questions_ui(diarize_model):
         if is_valid_dest_path:
             break
         else:
-            print("You entered an invalid destination path. Please try again")
+            print("You entered an invalid destination path. Please try again:")
 
     rprint("[blue]=============================[blue]")
     questions_finished_prompt = [

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -172,14 +172,7 @@ def questions_ui(diarize_model):
 
     while True:
         input_file = input()
-        input_audio_path = input_file.strip()  # remove leading and trailing whitespace
-        # Check 1 for input file: Validate whether path is valid
-        # audio_path_last_backslash_index = input_file.rfind("/")
-        # audio_name = input_file[audio_path_last_backslash_index + 1:]
-        # audio_name = audio_name.strip()  # remove leading and trailing whitespace
-        # TODO: Purposefully left out the "replace <spaces> with <"_"> since that might interfere with the path checking
-        # TODO: Moreover, having spaces in path name still yields an actual valid path (at least for MacOS)
-        # input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
+        input_audio_path = input_file.strip()  # remove leading and trailing whitespace from the input path ONLY
         is_valid_audio_path = validate_path(input_audio_path, True)
         if is_valid_audio_path:
             break

--- a/streetwhisperapp.py
+++ b/streetwhisperapp.py
@@ -174,12 +174,12 @@ def questions_ui(diarize_model):
         input_file = input()
         input_audio_path = input_file.strip()  # remove leading and trailing whitespace
         # Check 1 for input file: Validate whether path is valid
-        audio_path_last_backslash_index = input_file.rfind("/")
-        audio_name = input_file[audio_path_last_backslash_index + 1:]
-        audio_name = audio_name.strip()  # remove leading and trailing whitespace
+        # audio_path_last_backslash_index = input_file.rfind("/")
+        # audio_name = input_file[audio_path_last_backslash_index + 1:]
+        # audio_name = audio_name.strip()  # remove leading and trailing whitespace
         # TODO: Purposefully left out the "replace <spaces> with <"_"> since that might interfere with the path checking
         # TODO: Moreover, having spaces in path name still yields an actual valid path (at least for MacOS)
-        input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
+        # input_audio_path = (input_audio_path.strip())[0: input_audio_path.rfind("/") + 1] + audio_name
         is_valid_audio_path = validate_path(input_audio_path, True)
         if is_valid_audio_path:
             break


### PR DESCRIPTION
### PR Solution to #31 

This PR made 2 main changes

**Change #1**: The existing audio file format checking (in method `validate_audio_file`) has been moved from the backend script to `streetwhisperapp.py`. This would allow for more immediate error catching, and reprompt from the user. 

**Change #2**: Added a method called `validate_path` that checks whether a path is valid. The check is dependent on whether we are calling it for the purpose of checking for a valid file path, or a valid directory path. 

**Note**: In `validate_path`, probably no need check whether path has the correct permissions (read, write, execute) for now since this CLI is mainly aimed for non-technical folks (the likelihood of paths having custom permissions would be low). Though this might be an enhancement to consider down the road. This of course, is open for discussion

